### PR TITLE
Add the ability to address multiple email addresses.

### DIFF
--- a/octoprint_emailnotifier/__init__.py
+++ b/octoprint_emailnotifier/__init__.py
@@ -39,7 +39,6 @@ class EmailNotifierPlugin(octoprint.plugin.EventHandlerPlugin,
 	#~~ EventPlugin
 	
 	def on_event(self, event, payload):
-		
 		if event != "PrintDone":
 			return
 		
@@ -70,7 +69,8 @@ class EmailNotifierPlugin(octoprint.plugin.EventHandlerPlugin,
 		
 		try:
 			mailer = yagmail.SMTP(user={self._settings.get(['mail_username']):self._settings.get(['mail_useralias'])}, host=self._settings.get(['mail_server']))
-			mailer.send(to=self._settings.get(['recipient_address']), subject=title, contents=content, validate_email=False)
+			emails = [email.strip() for email in self._settings.get(['recipient_address']).split(',')]
+			mailer.send(to=emails, subject=title, contents=content, validate_email=False)
 		except Exception as e:
 			# report problem sending email
 			self._logger.exception("Email notification error: %s" % (str(e)))

--- a/octoprint_emailnotifier/templates/emailnotifier_settings.jinja2
+++ b/octoprint_emailnotifier/templates/emailnotifier_settings.jinja2
@@ -11,7 +11,7 @@
 	</div>
 
 	<div class="control-group" title="{{ _('Print complete notifications will be sent to this email address.') }}">
-		<label class="control-label">{{ _('Recipient Address') }}</label>
+		<label class="control-label">{{ _('Recipient Address (comma separated)') }}</label>
 		<div class="controls">
 			<input type="text" class="input-block-level" data-bind="value: settings.plugins.emailnotifier.recipient_address">
 		</div>

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_%s" % plugin_identifier
 plugin_name = "OctoPrint-EmailNotifier"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.1"
+plugin_version = "0.1.1"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
Thought I'd contribute this tiny piece of code.  I needed the ability to send to multiple addresses without creating a mailing list (1 to my email, 1 to my phone SMS email, and whomever wants to get notified in case they are watching my prints for me).  Yagmail allows you to create a list of email addresses.

I bumped the version number in my local copy.  I'm not sure if that should be merged or not if accepted.