### PR TITLE
Add 'Send test email' button

### DIFF
--- a/octoprint_emailnotifier/static/js/emailnotifier.js
+++ b/octoprint_emailnotifier/static/js/emailnotifier.js
@@ -1,0 +1,69 @@
+$(function() {
+    function EmailNotifierModel(parameters) {
+        var self = this;
+
+        // pull information from the custom bindings call below
+        self.loginState = parameters[0];
+        self.settingsViewModel = parameters[1];
+
+        // we will set our settings variable right before bind so that the template can be binded correctly
+        self.onBeforeBinding = function() {
+            self.settings = self.settingsViewModel.settings;
+        };
+
+        // state variables
+        self.testActive = ko.observable(false);
+        self.testResult = ko.observable(false);
+        self.testSuccessful = ko.observable(false);
+        self.testMessage = ko.observable();
+
+        self.testEmailConfiguration = function() {
+            // set our state variables
+            self.testActive(true);
+            self.testResult(false);
+            self.testSuccessful(false);
+            self.testMessage("");
+
+            var recipients = self.settings.plugins.emailnotifier.recipient_address();
+            var smtp = self.settings.plugins.emailnotifier.mail_server();
+            var user = self.settings.plugins.emailnotifier.mail_username();
+            var alias = self.settings.plugins.emailnotifier.mail_useralias();
+            var snapshot = self.settings.plugins.emailnotifier.include_snapshot();
+
+            var payload = {
+                command: "testmail",
+                recipients: recipients,
+                smtp: smtp,
+                user: user,
+                alias: alias,
+                snapshot: snapshot
+            };
+
+            $.ajax({
+                url: API_BASEURL + "plugin/emailnotifier",
+                type: "POST",
+                dataType: "json",
+                data: JSON.stringify(payload),
+                contentType: "application/json; charset=UTF-8",
+                success: function(response) {
+                    self.testResult(true);
+                    self.testSuccessful(response.success);
+                    if (!response.success && response.hasOwnProperty("msg")) {
+                        self.testMessage(response.msg);
+                    } else {
+                        self.testMessage(undefined);
+                    }
+                },
+                complete: function() {
+                    self.testActive(false);
+                }
+            });
+        };
+    };
+
+    ADDITIONAL_VIEWMODELS.push([
+        EmailNotifierModel,
+        ["loginStateViewModel", "settingsViewModel"],
+        [document.getElementById("settings_plugin_emailnotifier")]
+    ]);
+});

--- a/octoprint_emailnotifier/templates/emailnotifier_settings.jinja2
+++ b/octoprint_emailnotifier/templates/emailnotifier_settings.jinja2
@@ -41,7 +41,16 @@
 			<input type="text" class="input-block-level" data-bind="value: settings.plugins.emailnotifier.mail_useralias">
 		</div>
 	</div>
-	
+
+	<div class="control-group" title="{{ _('Send a test email. This will use the most recently saved configuration to send a test email.') }}">
+		<span data-bind="visible: testResult() && testSuccessful()">{{ _('Sent successfully!') }}</span>
+		<span data-bind="visible: testResult() && !testSuccessful()">{{ _('Sending failed. Reason:') }}: <span data-bind="text: testMessage"></span></span>
+		<button class="btn" data-bind="click: function() { testEmailConfiguration() }">
+			<i class="icon-spinner icon-spin" data-bind="visible: testActive()"></i>
+			{{ _('Send a test email') }}
+		</button>
+	</div>
+
 	<h4>{{ _('Message Content') }}</h4>
 	
 	<p>{{ _('The email title and body templates may contain the tags <code>{filename}</code> and <code>{elapsed_time}</code>.') }}</p>


### PR DESCRIPTION
Contains the changes for the test email button from @djvaporize 's master branch. I did a bit of cleanup, but the commit is still credited to him.

The changes that I made:
- Move the test email button up underneath the SMTP information because a) that's where it is in most other UIs and consistency is good, and b) The thing that users actually care about testing is that they have set up their SMTP creds properly.
- Reduce code duplication in **init**.py by moving the email sending logic to one method and calling it from the on_event() method and the on_api_command() method.

Sorry if there are any obvious errors here - I don't usually work on Python stuff, so I'm a bit rusty.

Hope this is helpful!

Fixes #7 
