### PR TITLE
Adding keyring.alt as requirement to be installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ plugin_url = "https://github.com/anoved/OctoPrint-EmailNotifier"
 plugin_license = "AGPLv3"
 
 # Any additional requirements besides OctoPrint should be listed here
-plugin_requires = ['yagmail']
+plugin_requires = ['yagmail', 'keyrings.alt']
 
 # Additional package data to install for this plugin. The subfolders "templates", "static" and "translations" will
 # already be installed automatically if they exist.


### PR DESCRIPTION
Since the keyring python module no longer includes the simple backends, the keyring.alt package needs to be installed also as discussed in this issue: https://github.com/jaraco/keyring/issues/196