### PR TITLE
Use explicit destination filename for snapshot

### DIFF
--- a/octoprint_emailnotifier/__init__.py
+++ b/octoprint_emailnotifier/__init__.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 import os
 import octoprint.plugin
 import yagmail
+import tempfile
 
 class EmailNotifierPlugin(octoprint.plugin.EventHandlerPlugin,
                           octoprint.plugin.SettingsPlugin,
@@ -61,11 +62,11 @@ class EmailNotifierPlugin(octoprint.plugin.EventHandlerPlugin,
 			if snapshot_url:
 				try:
 					import urllib
-					filename, headers = urllib.urlretrieve(snapshot_url)
+					filename, headers = urllib.urlretrieve(snapshot_url, tempfile.gettempdir()+"/snapshot.jpg")
 				except Exception as e:
 					self._logger.exception("Snapshot error (sending email notification without image): %s" % (str(e)))
 				else:
-					content.append({filename: "snapshot.jpg"})
+					content.append(yagmail.inline(filename))
 		
 		try:
 			mailer = yagmail.SMTP(user={self._settings.get(['mail_username']):self._settings.get(['mail_useralias'])}, host=self._settings.get(['mail_server']))


### PR DESCRIPTION
Should fix #5 and fix #18  

yagmail tries to "guess" MIME type for attachments using filename extension. However, urllib.urlretrieve writes retrieved content to a temporary file with no extension, so yagmail is unable to determine that attachment is an image and use the correct content-type.  By using an explicit destination filename with a ".jpg" extension, yagmail will use Content-type: image/jpeg for the MIME object and, hopefully, email clients will handle appropriately [#18].

Also, by using the yagmail inline type, image will be embedded in the body of the email's HTML part rather that as an attachment (on `yagmail>=0.5.156`) [#5].  Note that this may be undesirable to some--if they prefer it as a true attachment, rather than inline.  Might be better to have this as a configuration option?